### PR TITLE
ci: split build and publish

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -3,15 +3,10 @@ name: CI-CD
 on: [push]
 
 jobs:
-  build_and_publish:
+  build:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
-      id-token: write
-    environment:
-      name: pypi
-      url: https://pypi.org/p/data-factory-testing-framework
     steps:
       #----------------------------------------------
       #       check-out repo and set-up python
@@ -53,8 +48,30 @@ jobs:
         run: |
           poetry version 0.0.1.alpha${{ github.run_number}}
           poetry build
+      #----------------------------------------------
+      # upload dist
+      #----------------------------------------------
+      - name: Upload dist
+        uses: actions/upload-artifact@v3
+        with:
+          name: dist
+          path: dist
+  publish:
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/p/data-factory-testing-framework
+    steps:
+      - name: Download dist
+        uses: actions/download-artifact@v3
+        with:
+          name: dist
+          path: dist
       - name: Publish package distributions to PyPI
-        if: github.ref == 'refs/heads/main'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: ./dist


### PR DESCRIPTION
Splitting `build_and_publish` to prevent creating deployment when workflow runs (addressing #56 ).