### PR TITLE
ci: add pre-commit linting and testing

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -40,10 +40,13 @@ jobs:
       - name: Install project
         run: poetry install --no-interaction
       #----------------------------------------------
-      #              run test suite
+      #              run linting and tests
       #----------------------------------------------
-      - name: Run tests
-        run: poetry run pytest .
+      - name: Run linting and tests
+        run: poetry run pre-commit run --all-files --show-diff-on-failure
+      #----------------------------------------------
+      #              build package
+      #----------------------------------------------
       - name: Set build version and build package
         run: |
           poetry version 0.0.1.alpha${{ github.run_number}}


### PR DESCRIPTION
Using the pre-commit tool for CI by calling `pre-commit run --all-files --show-diff-on-failure`. It allows to run current checks we also run locally in CI. Helps keep checks consistent. Tested on Windows and Ubuntu 22.04 with poetry 1.6.1.

Closes #58 