### PR TITLE
ci: add conventional commit checks

### DIFF
--- a/.conventional-commits/commitlint.pr.config.js
+++ b/.conventional-commits/commitlint.pr.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+    extends: ['@commitlint/config-conventional'],
+    defaultIgnores: false,
+};

--- a/.conventional-commits/commitlint.precommit.config.js
+++ b/.conventional-commits/commitlint.precommit.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+    extends: ['@commitlint/config-conventional'],
+    defaultIgnores: false,
+    ignores: [
+        // allow fixup and squash commits for precommit checks
+        (c) => new RegExp('(fixup|squash)!').test(c),
+    ],
+};

--- a/.conventional-commits/scripts/lint-pull-request.sh
+++ b/.conventional-commits/scripts/lint-pull-request.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+PR_TITLE="$1"
+PR_BODY="$2"
+COMMIT_LINT_CONFIG="$3"
+
+npm install -g @commitlint/cli@17 @commitlint/config-conventional@17
+
+echo "$PR_TITLE\n\n$PR_BODY" | commitlint --config "$COMMIT_LINT_CONFIG" --verbose

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,16 @@
+---
+name: Conventional Commits
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    types: [opened, reopened, edited, synchronize]
+  workflow_dispatch:  # yamllint disable-line rule:empty-values
+jobs:
+  lint-pull-request:
+    name: Lint Pull Request
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: PR Linting
+        run: |
+          .conventional-commits/scripts/lint-pull-request.sh '${{ github.event.pull_request.title }}' '${{ github.event.pull_request.body }}' '${{ github.workspace }}/.conventional-commits/commitlint.pr.config.js'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,13 @@
 ---
+default_install_hook_types: [pre-commit, pre-push, commit-msg]
 repos:
+  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+    rev: v9.5.0
+    hooks:
+      - id: commitlint
+        stages: [commit-msg]
+        args: [--config, ./.conventional-commits/commitlint.precommit.config.js]
+        additional_dependencies: ['@commitlint/config-conventional']
   - repo: https://github.com/python-poetry/poetry
     rev: 1.6.1
     hooks:


### PR DESCRIPTION
add conventional commit checks on pull requests and add helper for pre-commit hooks
to avoid non cc commit messages. pre-commit hooks are optional but enforced locally
when installed via `pre-commit install` unless opted out.