### PR TITLE
fix: format-datetime naming in function repository

### DIFF
--- a/src/data_factory_testing_framework/functions/functions_repository.py
+++ b/src/data_factory_testing_framework/functions/functions_repository.py
@@ -46,7 +46,7 @@ class FunctionsRepository:
         "equals": logical_functions.equals,
         "first": collection_functions.first,
         "float": conversion_functions.float_,
-        "formatDataTime": date_functions.format_date_time,
+        "formatDateTime": date_functions.format_date_time,
         "getFutureTime": date_functions.get_future_time,
         "getPastTime": date_functions.get_past_time,
         "greater": logical_functions.greater,


### PR DESCRIPTION
Fixes the issue #64 partially. The dotnet datetime implementation will solve the other part.