### PR TITLE
fix: execute_pipeline_activity.py defaults back to empty parameters

### DIFF
--- a/src/data_factory_testing_framework/models/activities/execute_pipeline_activity.py
+++ b/src/data_factory_testing_framework/models/activities/execute_pipeline_activity.py
@@ -19,7 +19,9 @@ class ExecutePipelineActivity(ControlActivity):
 
         super(ControlActivity, self).__init__(**kwargs)
 
-        self.parameters: dict = self.type_properties["parameters"]
+        self.parameters: dict = {}
+        if "parameters" in self.type_properties:
+            self.parameters = self.type_properties["parameters"]
 
     def get_child_run_parameters(self, state: PipelineRunState) -> List[RunParameter]:
         child_parameters = []

--- a/tests/unit/models/activities/test_execute_pipeline_activity_parameters.py
+++ b/tests/unit/models/activities/test_execute_pipeline_activity_parameters.py
@@ -1,0 +1,47 @@
+from data_factory_testing_framework.models.activities.execute_pipeline_activity import ExecutePipelineActivity
+from data_factory_testing_framework.models.data_factory_element import DataFactoryElement
+from data_factory_testing_framework.state import PipelineRunState, RunParameter, RunParameterType
+
+
+def test_execute_pipeline_activity_evaluates_parameters() -> None:
+    # Arrange
+    execute_pipeline_activity = ExecutePipelineActivity(
+        name="ExecutePipelineActivity",
+        typeProperties={
+            "parameters": {
+                "url": DataFactoryElement("@pipeline().parameters.param1"),
+            },
+        },
+        depends_on=[],
+    )
+    state = PipelineRunState(
+        parameters=[
+            RunParameter(name="param1", value="value1", parameter_type=RunParameterType.Pipeline),
+        ],
+    )
+
+    # Act
+    activity = execute_pipeline_activity.evaluate(state)
+
+    # Assert
+    assert activity is not None
+    assert activity.name == "ExecutePipelineActivity"
+    assert activity.parameters["url"].value == "value1"
+
+
+def test_execute_pipeline_activity_evaluates_no_parameters() -> None:
+    # Arrange
+    execute_pipeline_activity = ExecutePipelineActivity(
+        name="ExecutePipelineActivity",
+        typeProperties={},
+        depends_on=[],
+    )
+    state = PipelineRunState()
+
+    # Act
+    activity = execute_pipeline_activity.evaluate(state)
+
+    # Assert
+    assert activity is not None
+    assert activity.name == "ExecutePipelineActivity"
+    assert activity.parameters == {}


### PR DESCRIPTION
Addresses #68 