### PR TITLE
ci: add ci/cd with gitversion, releases and e2e test

### DIFF
--- a/.conventional-commits/GitVersion.yml
+++ b/.conventional-commits/GitVersion.yml
@@ -1,0 +1,13 @@
+---
+assembly-versioning-scheme: MajorMinorPatch
+mode: Mainline
+ignore:
+  sha: []
+merge-message-formats: {}
+
+# Conventional Commit Reference
+# https://www.conventionalcommits.org/en/v1.0.0/
+# https://gitversion.net/docs/reference/version-increments#manually-incrementing-the-version
+major-version-bump-message: "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([\\w\\s-]*\\))?(!:|:.*\\n\\n((.+\\n)+\\n)?BREAKING CHANGE:\\s.+)"
+minor-version-bump-message: "^(feat)(\\([\\w\\s-]*\\))?:"
+patch-version-bump-message: "^(build|chore|ci|docs|fix|perf|refactor|revert|style|test)(\\([\\w\\s-]*\\))?:"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,38 @@
+---
+name: CD
+
+on:
+  workflow_call: # yamllint disable-line rule:truthy
+    inputs:
+      version:
+        description: 'The version of the package'
+        required: true
+        type: string
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/p/data-factory-testing-framework
+    steps:
+      - name: Download sdist
+        uses: actions/download-artifact@v3
+        with:
+          name: dist
+          path: dist
+      - name: Download whl
+        uses: actions/download-artifact@v3
+        with:
+          name: whl
+          path: dist
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: ./dist
+      - name: Create release
+        run: gh release create ${{ inputs.version }} --prerelease --target ${{ github.ref }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -4,78 +4,26 @@ name: CI-CD
 on: [push]  # yamllint disable-line rule:truthy
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      # ----------------------------------------------
-      #       check-out repo and set-up python
-      # ----------------------------------------------
-      - name: Check out repository
-        uses: actions/checkout@v3
-      - name: Set up python
-        id: setup-python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.9'
-      # ----------------------------------------------
-      #  -----  install & configure poetry  -----
-      # ----------------------------------------------
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
-        with:
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-          installer-parallel: true
-
-      # ----------------------------------------------
-      # install dependencies if cache does not exist
-      # ----------------------------------------------
-      - name: Install dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --no-root
-      # ----------------------------------------------
-      # install your root project, if required
-      # ----------------------------------------------
-      - name: Install project
-        run: poetry install --no-interaction
-      #----------------------------------------------
-      #              run linting and tests
-      #----------------------------------------------
-      - name: Run linting and tests
-        run: poetry run pre-commit run --all-files --show-diff-on-failure
-      #----------------------------------------------
-      #              build package
-      #----------------------------------------------
-      - name: Set build version and build package
-        run: |
-          poetry version 0.1.0.alpha${{ github.run_number}}
-          poetry build
-      # ----------------------------------------------
-      # upload dist
-      # ----------------------------------------------
-      - name: Upload dist
-        uses: actions/upload-artifact@v3
-        with:
-          name: dist
-          path: dist
-  publish:
-    needs: build
+  ci:
+    uses: ./.github/workflows/ci.yml
+  e2e:
+    needs: ci
+    strategy:
+      matrix:
+        os: ['ubuntu-latest', 'windows-latest']
+        python-version: ['3.9', '3.10', '3.11']
+        dotnet-version: [3.1.x, '8.0.x']
+        # test either wheel or source distribution
+        dist: [whl, sdist]
+    uses: ./.github/workflows/e2e.yml
+    with:
+      os: ${{ matrix.os }}
+      python-version: ${{ matrix.python-version }}
+      dotnet-version: ${{ matrix.dotnet-version }}
+      dist: ${{ matrix.dist }}
+  cd:
+    needs: [ci, e2e]
     if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-    environment:
-      name: pypi
-      url: https://pypi.org/p/data-factory-testing-framework
-    steps:
-      - name: Download dist
-        uses: actions/download-artifact@v3
-        with:
-          name: dist
-          path: dist
-      - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: ./dist
+    uses: ./.github/workflows/cd.yml
+    with:
+      version: ${{ needs.ci.outputs.version }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -24,6 +24,8 @@ jobs:
   cd:
     needs: [ci, e2e]
     if: github.ref == 'refs/heads/main'
+    permissions:
+      id-token: write
     uses: ./.github/workflows/cd.yml
     with:
       version: ${{ needs.ci.outputs.version }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -6,23 +6,8 @@ on: [push]  # yamllint disable-line rule:truthy
 jobs:
   ci:
     uses: ./.github/workflows/ci.yml
-  e2e:
-    needs: ci
-    strategy:
-      matrix:
-        os: ['ubuntu-latest', 'windows-latest']
-        python-version: ['3.9', '3.10', '3.11']
-        dotnet-version: [3.1.x, '8.0.x']
-        # test either wheel or source distribution
-        dist: [whl, sdist]
-    uses: ./.github/workflows/e2e.yml
-    with:
-      os: ${{ matrix.os }}
-      python-version: ${{ matrix.python-version }}
-      dotnet-version: ${{ matrix.dotnet-version }}
-      dist: ${{ matrix.dist }}
   cd:
-    needs: [ci, e2e]
+    needs: [ci]
     if: github.ref == 'refs/heads/main'
     permissions:
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Run linting and tests
         run: poetry run pre-commit run --all-files --show-diff-on-failure
       - name: Set build version and build package
-        run: | 
+        run: |
           poetry version $BUILD_VERSION
           poetry build
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,81 @@
+---
+name: CI
+
+on:
+  workflow_call: # yamllint disable-line rule:truthy
+    outputs:
+      version:
+        description: 'The version of the package'
+        value: ${{ jobs.version.outputs.version }}
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.set-version.outputs.GITVERSION_SEMVER }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          # to calculate the version we need the tags and the commit history
+          fetch-tags: true
+          fetch-depth: 0
+      - name: Install GitVersion
+        uses: gittools/actions/gitversion/setup@v0
+        with:
+          versionSpec: '5.x'
+      - name: Determine Version
+        id: gitversion
+        uses: gittools/actions/gitversion/execute@v0
+        with:
+          useConfigFile: true
+          configFilePath: './.conventional-commits/GitVersion.yml'
+      - name: Set version output
+        id: set-version
+        run: echo "GITVERSION_SEMVER=$GitVersion_MajorMinorPatch$SUFFIX" >> $GITHUB_OUTPUT
+        env:
+          SUFFIX: ${{ github.ref != 'refs/heads/main' && format('.dev{0}+{1}', github.run_number, env.GitVersion_ShortSha) || '' }}
+  build:
+    runs-on: ubuntu-latest
+    needs: version
+    permissions:
+      contents: read
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Set up python
+        id: setup-python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          installer-parallel: true
+      - name: Install dependencies
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        run: poetry install --no-interaction --no-root
+      - name: Install project
+        run: poetry install --no-interaction
+      - name: Run linting and tests
+        run: poetry run pre-commit run --all-files --show-diff-on-failure
+      - name: Set build version and build package
+        run: | 
+          poetry version $BUILD_VERSION
+          poetry build
+        env:
+          BUILD_VERSION: ${{ needs.version.outputs.version }}
+      - name: Upload dist
+        uses: actions/upload-artifact@v3
+        with:
+          name: whl
+          path: dist/*.whl
+      - name: Upload sdist
+        uses: actions/upload-artifact@v3
+        with:
+          name: sdist
+          path: dist/*.tar.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,3 +79,18 @@ jobs:
         with:
           name: sdist
           path: dist/*.tar.gz
+  e2e:
+    needs: build
+    strategy:
+      matrix:
+        os: ['ubuntu-latest', 'windows-latest']
+        python-version: ['3.9', '3.10', '3.11']
+        dotnet-version: ['3.1.x', '8.0.x']
+        # test either wheel or source distribution
+        dist: [whl, sdist]
+    uses: ./.github/workflows/e2e.yml
+    with:
+      os: ${{ matrix.os }}
+      python-version: ${{ matrix.python-version }}
+      dotnet-version: ${{ matrix.dotnet-version }}
+      dist: ${{ matrix.dist }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,51 @@
+---
+name: CD
+
+on:
+  workflow_call: # yamllint disable-line rule:truthy
+    inputs:
+      os:
+        description: 'Operating system'
+        required: true
+        type: string
+      python-version:
+        description: 'Python version'
+        required: true
+        type: string
+      dotnet-version:
+        description: '.NET version'
+        required: true
+        type: string
+      dist:
+        description: 'Distribution artifact'
+        required: true
+        type: string
+
+jobs:
+  e2e:
+    runs-on: ${{ inputs.os }}
+    permissions:
+      contents: read
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+      - name: Set up python
+        id: setup-python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ inputs.python-version }}
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ inputs.dotnet-version }}
+      - name: Download dist
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ inputs.dist }}
+          path: dist
+      - name: Install pytest
+        run: python -m pip install pytest
+      - name: Install project
+        run: pip install $(ls)
+        working-directory: dist
+      - name: Run end-to-end tests
+        run: python -m pytest examples


### PR DESCRIPTION
adds a ci/cd process with gitversion, release creation and e2e tests.
GitVersion follows semantic versioning based on conventional commits, where types with `!` introduce a breaking change and bump major. `feat` bumps the minor version and other's bump the minor.