### PR TITLE
fix: get pipeline by name not id in Data Factory and Synapse

### DIFF
--- a/src/data_factory_testing_framework/_repositories/data_factory_repository.py
+++ b/src/data_factory_testing_framework/_repositories/data_factory_repository.py
@@ -38,4 +38,4 @@ class DataFactoryRepository:
             if pipeline.name == name:
                 return pipeline
 
-        raise PipelineNotFoundError(f"Pipeline with name {name} not found")
+        raise PipelineNotFoundError(f"Pipeline with name: '{name}' not found")

--- a/src/data_factory_testing_framework/_test_framework.py
+++ b/src/data_factory_testing_framework/_test_framework.py
@@ -158,7 +158,7 @@ class TestFramework:
                     if isinstance(activity, ExecutePipelineActivity) and self.should_evaluate_child_pipelines:
                         execute_pipeline_activity: ExecutePipelineActivity = activity
                         pipeline: Pipeline = None
-                        if self._framework_type == TestFrameworkType.Fabric:
+                        if self.framework_type == TestFrameworkType.Fabric:
                             pipeline = self.get_pipeline_by_id(
                                 # Note: in the future they will probably rename this to referenceId for Fabric
                                 execute_pipeline_activity.type_properties["pipeline"]["referenceName"],

--- a/tests/functional/api/classes/test_test_framework_api.py
+++ b/tests/functional/api/classes/test_test_framework_api.py
@@ -23,6 +23,7 @@ def test_test_framework_api() -> None:
         "evaluate_activities",
         "evaluate_activity",
         "evaluate_pipeline",
+        "framework_type",
         "get_pipeline_by_id",
         "get_pipeline_by_name",
         "should_evaluate_child_pipelines",
@@ -43,6 +44,7 @@ def test_test_framework_method_types() -> None:
         "evaluate_pipeline": types.FunctionType,
         "get_pipeline_by_id": types.FunctionType,
         "get_pipeline_by_name": types.FunctionType,
+        "framework_type": property,
         "should_evaluate_child_pipelines": property,
     }
 
@@ -55,7 +57,8 @@ def test_test_framework_method_properties() -> None:
     properties = [method[0] for method in inspect.getmembers(TestFramework, predicate=utils.is_property)]
 
     # Assert
-    assert properties == ["should_evaluate_child_pipelines"]
+    assert properties == ["framework_type", "should_evaluate_child_pipelines"]
+    assert TestFramework.framework_type.fget.__annotations__ == {"return": str}
     assert TestFramework.should_evaluate_child_pipelines.fget.__annotations__ == {"return": bool}
 
 

--- a/tests/functional/execute_child_pipeline_data_factory/test_execute_pipeline_activity_data_factory.py
+++ b/tests/functional/execute_child_pipeline_data_factory/test_execute_pipeline_activity_data_factory.py
@@ -57,4 +57,4 @@ def test_execute_pipeline_activity_evaluate_child_pipelines_child_pipeline_not_k
             ),
         )
 
-    assert exception_info.value.args[0] == "Pipeline with name Pipeline with pipeline_id: 'child' not found not found"
+    assert exception_info.value.args[0] == "Pipeline with name Pipeline with name: 'child' not found not found"


### PR DESCRIPTION
Use get_pipeline_by_name in the case of Data Factory or Synapse as they use the name not ID similar to Fabric.