### PR TITLE
fix: change expression language transformer to be case insensitive

### DIFF
--- a/src/data_factory_testing_framework/_expression_runtime/data_factory_expression/expression_transformer.py
+++ b/src/data_factory_testing_framework/_expression_runtime/data_factory_expression/expression_transformer.py
@@ -106,7 +106,7 @@ class ExpressionTransformer:
         self.lark_parser = Lark(grammer, start="start", maybe_placeholders=False)
 
     def _supported_functions(self) -> str:
-        functions = [f'"{f}"' for f in FunctionsRepository._functions]
+        functions = [f'"{f}"i' for f in FunctionsRepository._functions]
         return " | ".join(functions)
 
     def _parse(self, expression: str) -> Tree[Token]:

--- a/tests/unit/functions/test_data_factory_testing_framework_expression_evaluator.py
+++ b/tests/unit/functions/test_data_factory_testing_framework_expression_evaluator.py
@@ -355,6 +355,18 @@ def test_evaluate(
     assert actual == expected_evaluation
 
 
+def test_evaluate_function_names_are_case_insensitive() -> None:
+    # Arrange
+    expression = "@CONCAT('a', 'b')"
+    expression_runtime = ExpressionRuntime()
+    state = PipelineRunState()
+
+    # Act
+    evaluated_value = expression_runtime.evaluate(expression, state)
+
+    # Assert
+    assert evaluated_value == "ab"
+
 def test_evaluate_parameter_with_complex_object_and_array_index() -> None:
     # Arrange
     expression = "@pipeline().parameters.parameter[0].field1.field2"

--- a/tests/unit/functions/test_data_factory_testing_framework_expression_evaluator.py
+++ b/tests/unit/functions/test_data_factory_testing_framework_expression_evaluator.py
@@ -367,6 +367,7 @@ def test_evaluate_function_names_are_case_insensitive() -> None:
     # Assert
     assert evaluated_value == "ab"
 
+
 def test_evaluate_parameter_with_complex_object_and_array_index() -> None:
     # Arrange
     expression = "@pipeline().parameters.parameter[0].field1.field2"


### PR DESCRIPTION
making the lark expression parser case insensitive for function names.

Fixes #142 