### PR TITLE
feat: add the option to add an error to an ActivityResult

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -6,6 +6,14 @@
 
 * poetry == 1.6.1
 
+### Installing the project
+
+Make sure to create a virtual environment and install the requirements by running:
+`poetry install --with dev`
+
+Build the .NET project:
+`dotnet build`
+
 ### Pre-Commit Hooks
 
 We use pre-commit hooks to ensure that the code is formatted correctly and that the code is linted before committing.

--- a/src/data_factory_testing_framework/_pythonnet/data_factory_testing_framework_expressions_evaluator.py
+++ b/src/data_factory_testing_framework/_pythonnet/data_factory_testing_framework_expressions_evaluator.py
@@ -42,6 +42,7 @@ class DataFactoryTestingFrameworkExpressionsEvaluator:
                     "body": {
                         "output": activity.output,
                         "status": activity.status,
+                        "error": activity.error,
                     }
                 }
             }

--- a/src/data_factory_testing_framework/state/_activity_result.py
+++ b/src/data_factory_testing_framework/state/_activity_result.py
@@ -9,6 +9,7 @@ class ActivityResult:
         activity_name: str,
         status: Optional[DependencyCondition] = None,
         output: Optional[Any] = None,  # noqa: ANN401
+        error: Optional[Any] = None,  # noqa: ANN401
     ) -> None:
         """Represents the result of an activity.
 
@@ -16,10 +17,12 @@ class ActivityResult:
             activity_name: Name of the activity.
             status: Status of the activity.
             output: Output of the activity. (e.g. { "count": 1 } for activity('activityName').output.count)
+            error: Error of the activity. (e.g. { "code": "ErrorCode", "message": "ErrorMessage" } for activity('activityName').Error)
         """
         self.activity_name = activity_name
         self.status = status if status is not None else DependencyCondition.SUCCEEDED
         self.output = output
+        self.error = error
 
     def __getitem__(self, item: str) -> Any:  # noqa: ANN401
         return getattr(self, item)

--- a/tests/unit/functions/test_data_factory_testing_framework_expression_evaluator.py
+++ b/tests/unit/functions/test_data_factory_testing_framework_expression_evaluator.py
@@ -390,6 +390,21 @@ from pytest import param as p
             "value1",
             id="activity_reference_with_nested_property_and_string_reference",
         ),
+        p(
+            "@activity('Error activity').Error.message",
+            PipelineRunState(
+                activity_results=[
+                    ActivityResult(
+                        activity_name="Error activity",
+                        status=DependencyCondition.FAILED,
+                        error={"message": "Oh no, something went wrong"},
+                    )
+                ],
+            ),
+            "@activity('Error activity').Error.message",
+            "Oh no, something went wrong",
+            id="activity_reference_with_error_message",
+        ),
     ],
 )
 def test_evaluate(


### PR DESCRIPTION
This PR adds the possibility to mock error messages coming from `ActivityResults` with the status of `FAILED`. This will allow users to evaluate expression that depend on the error message, for example:

`@contains(activity('Fetch some resources').Error.message, 'The specified resource does not exist.')`