### PR TITLE
fix: only add activity output property if not none

### DIFF
--- a/examples/data_factory/copy_blobs/test_data_factory_copy_blobs_unit.py
+++ b/examples/data_factory/copy_blobs/test_data_factory_copy_blobs_unit.py
@@ -7,6 +7,7 @@ from data_factory_testing_framework.state import (
     RunParameter,
     RunParameterType,
 )
+from data_factory_testing_framework.state._dependency_condition import DependencyCondition
 
 
 @pytest.fixture
@@ -61,7 +62,7 @@ def test_for_each(pipeline: Pipeline) -> None:
     )
     state.add_activity_result(
         activity_name="List Folders",
-        status="Succeeded",
+        status=DependencyCondition.SUCCEEDED,
         output={
             "Response": """
                     <EnumerationResults ServiceEndpoint="http://myaccount.blob.core.windows.net/"  ContainerName="mycontainer">

--- a/examples/synapse/copy_blobs/test_synapse_copy_blobs_unit.py
+++ b/examples/synapse/copy_blobs/test_synapse_copy_blobs_unit.py
@@ -7,6 +7,7 @@ from data_factory_testing_framework.state import (
     RunParameter,
     RunParameterType,
 )
+from data_factory_testing_framework.state._dependency_condition import DependencyCondition
 
 
 @pytest.fixture
@@ -61,7 +62,7 @@ def test_for_each(pipeline: Pipeline) -> None:
     )
     state.add_activity_result(
         activity_name="List Folders",
-        status="Succeeded",
+        status=DependencyCondition.SUCCEEDED,
         output={
             "Response": """
                     <EnumerationResults ServiceEndpoint="http://myaccount.blob.core.windows.net/"  ContainerName="mycontainer">

--- a/src/data_factory_testing_framework/_pythonnet/data_factory_testing_framework_expressions_evaluator.py
+++ b/src/data_factory_testing_framework/_pythonnet/data_factory_testing_framework_expressions_evaluator.py
@@ -37,16 +37,16 @@ class DataFactoryTestingFrameworkExpressionsEvaluator:
 
         activity_results = {}
         for activity in state.activity_results:
-            activity_result_dir = {
-                "outputs": {
-                    "body": {
-                        "output": activity.output,
-                        "status": activity.status,
-                        "error": activity.error,
-                    }
-                }
+            output_body = {
+                k: v
+                for k, v in {
+                    "error": activity.error,
+                    "output": activity.output,
+                    "status": activity.status.value if activity.status is not None else None,
+                }.items()
+                if v is not None
             }
-            activity_results[activity.activity_name] = activity_result_dir
+            activity_results[activity.activity_name] = {"outputs": {"body": output_body}}
 
         variables = {variable.name: variable.value for variable in state.variables}
 

--- a/src/data_factory_testing_framework/state/_activity_result.py
+++ b/src/data_factory_testing_framework/state/_activity_result.py
@@ -7,7 +7,7 @@ class ActivityResult:
     def __init__(
         self,
         activity_name: str,
-        status: Optional[DependencyCondition] = None,
+        status: Optional[DependencyCondition] = DependencyCondition.SUCCEEDED,
         output: Optional[Any] = None,  # noqa: ANN401
         error: Optional[Any] = None,  # noqa: ANN401
     ) -> None:
@@ -20,7 +20,7 @@ class ActivityResult:
             error: Error of the activity. (e.g. { "code": "ErrorCode", "message": "ErrorMessage" } for activity('activityName').Error)
         """
         self.activity_name = activity_name
-        self.status = status if status is not None else DependencyCondition.SUCCEEDED
+        self.status = status
         self.output = output
         self.error = error
 

--- a/tests/unit/functions/test_data_factory_testing_framework_expression_evaluator.py
+++ b/tests/unit/functions/test_data_factory_testing_framework_expression_evaluator.py
@@ -445,16 +445,30 @@ def test_evaluate_function_names_are_case_insensitive() -> None:
     # Assert
     assert evaluated_value == "ab"
 
+
 @pytest.mark.parametrize(
     ["expression", "property_name"],
     [
-        p("@contains(createArray(activity('Fail').status,activity('Notebook').status),'Failed')", "status", id="status"),
-        p("@contains(createArray(activity('Fail').status,activity('Notebook').error),'Succeeded')", "error", id="error"),
-        p("@contains(createArray(activity('Fail').status,activity('Notebook').output),'Succeeded')", "output", id="output"),
+        p(
+            "@contains(createArray(activity('Fail').status,activity('Notebook').status),'Failed')",
+            "status",
+            id="status",
+        ),
+        p(
+            "@contains(createArray(activity('Fail').status,activity('Notebook').error),'Succeeded')",
+            "error",
+            id="error",
+        ),
+        p(
+            "@contains(createArray(activity('Fail').status,activity('Notebook').output),'Succeeded')",
+            "output",
+            id="output",
+        ),
     ],
 )
 def test_evaluate_expression_with_none_activity_result_raises_exception(
-    expression: str, property_name: str,
+    expression: str,
+    property_name: str,
 ) -> None:
     # Arrange
     expression_runtime = ExpressionRuntime()

--- a/tests/unit/functions/test_data_factory_testing_framework_expression_evaluator.py
+++ b/tests/unit/functions/test_data_factory_testing_framework_expression_evaluator.py
@@ -445,6 +445,41 @@ def test_evaluate_function_names_are_case_insensitive() -> None:
     # Assert
     assert evaluated_value == "ab"
 
+@pytest.mark.parametrize(
+    ["expression", "property_name"],
+    [
+        p("@contains(createArray(activity('Fail').status,activity('Notebook').status),'Failed')", "status", id="status"),
+        p("@contains(createArray(activity('Fail').status,activity('Notebook').error),'Succeeded')", "error", id="error"),
+        p("@contains(createArray(activity('Fail').status,activity('Notebook').output),'Succeeded')", "output", id="output"),
+    ],
+)
+def test_evaluate_expression_with_none_activity_result_raises_exception(
+    expression: str, property_name: str,
+) -> None:
+    # Arrange
+    expression_runtime = ExpressionRuntime()
+    state = PipelineRunState(
+        activity_results=[
+            ActivityResult(
+                activity_name="Fail",
+                status=DependencyCondition.FAILED,
+                output={},
+            ),
+            ActivityResult(
+                activity_name="Notebook",
+                status=None,
+                output=None,
+                error=None,
+            ),
+        ]
+    )
+
+    # Act & Assert
+    with pytest.raises(ParameterNotFoundError) as exinfo:
+        expression_runtime.evaluate(expression, state)
+
+    assert str(exinfo.value) == f"Parameter: '{property_name}' of type 'RunParameterType.System' not found"
+
 
 def test_evaluate_function_with_null_conditional_operator() -> None:
     # Arrange


### PR DESCRIPTION
This PR fixes an issue where activity properties with `None` values were incorrectly included in the activity result dictionary, causing that no parameter not found errors are thrown when expressions tried to access non-existent properties as they are passed as `None`.

- Updates the expression evaluator to only include activity properties in the output body when they are not `None`
- Changes the default status from being automatically set to `SUCCEEDED` to allowing explicit `None` values
- Adds comprehensive test coverage for scenarios where activity properties are `None`

Fixes #164 